### PR TITLE
docs: rename "fortmatic" to "magic"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ _Click [here](https://docs.google.com/spreadsheets/d/16wljlyeSz7bjZkijx2YtL9lmSz
 * Hardware Token 2FA: The wallet provides a hardware token 2FA
 * Hardware Wallet Integration: The wallet allows the use of hardware wallets
 * Transaction Firewall: Trnsactions can be checked against a firewall to prevent malicious behavior
-* Off-hain Login: An on-chain transaction is not needed for logins from different devices
+* Off-Chain Login: An on-chain transaction is not needed for logins from different devices
 * No Mobile App Required: A mobile app is not required when using the wallet
 * No Hardware Required: No hardware is required when using the wallet
 * Sandboxed Key Storage: Keys are sandboxed in secured storage or iframes and not easily accessible

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Click [here](https://docs.google.com/spreadsheets/d/16wljlyeSz7bjZkijx2YtL9lmSz
 
 <div align="right"><img width="32" height="32" src="media/scroll.png"></div>
 
-|  | [Authereum](https://authereum.org) | [Universal Login](https://universallogin.io/) | [Portis](https://www.portis.io/) | [Argent](https://www.argent.xyz/) | [Metamask](https://metamask.io/) | [Abridged](https://abridged.github.io/splash/) | [Gnosis Safe](https://safe.gnosis.io/) | [Fortmatic](https://fortmatic.com/) | [Torus](https://tor.us) | [Dapper](https://www.dapperlabs.com/) | [Coinbase Wallet](https://wallet.coinbase.com/) | [Status](https://status.im/) | [Trust Wallet](https://trustwallet.com/) | [Ledger](https://www.ledger.com/) | [Squarelink](https://squarelink.com) | [ETHVault](https://ethvault.xyz) | [NiftyWallet](https://github.com/poanetwork/nifty-wallet) | [Bitski](https://bitski.com) | [BRD](http://breadapp.com) |
+|  | [Authereum](https://authereum.org) | [Universal Login](https://universallogin.io/) | [Portis](https://www.portis.io/) | [Argent](https://www.argent.xyz/) | [Metamask](https://metamask.io/) | [Abridged](https://abridged.github.io/splash/) | [Gnosis Safe](https://safe.gnosis.io/) | [Magic](https://magic.link/) | [Torus](https://tor.us) | [Dapper](https://www.dapperlabs.com/) | [Coinbase Wallet](https://wallet.coinbase.com/) | [Status](https://status.im/) | [Trust Wallet](https://trustwallet.com/) | [Ledger](https://www.ledger.com/) | [Squarelink](https://squarelink.com) | [ETHVault](https://ethvault.xyz) | [NiftyWallet](https://github.com/poanetwork/nifty-wallet) | [Bitski](https://bitski.com) | [BRD](http://breadapp.com) |
 |---| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 |ENS Integration                 | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
 |No Chrome Extension Required    | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
@@ -31,7 +31,7 @@ _Click [here](https://docs.google.com/spreadsheets/d/16wljlyeSz7bjZkijx2YtL9lmSz
 |Web2.0 Style Login              | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ |
 |Purchase ETH/Tokens In App      | ✅ | ❌ | ✅ | ✅ | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ |
 |Web3 Provider Available         | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ |
-|Software Token 2FA              | ✅ | ❌ | ✅ | ❌ | ❌ | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+|Software Token 2FA              | ✅ | ❌ | ✅ | ❌ | ❌ | 🔜 | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
 |Hardware Token 2FA              | ✅ | ❌ | ❌ | ❌ | ❌ | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 |Hardware Wallet Integration     | ✅ | ❌ | ❌ | ❌ | ✅ | 🔜 | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
 |Transaction Firewall            | ✅ | ❌ | ❌ | ✅ | ❌ | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |


### PR DESCRIPTION
As per their [recent announcement](https://twitter.com/fortmatic/status/1266356854227005440), Fortmatic has rebranded to [Magic Labs](https://twitter.com/magic_labs).

Changelog:

- [x] Update the Magic name
- [x] Mark Software 2FA as checked for "Magic", since they have this feature
- [x] Fix a typo in the README: "Off-hain Login"

<img width="366" alt="Capture d’écran 2020-06-07 à 15 42 10" src="https://user-images.githubusercontent.com/8782666/83969022-f62f0b00-a8d5-11ea-9c48-3df4ea16e06a.png">